### PR TITLE
message() can accept a params array ref

### DIFF
--- a/lib/Catalyst/Plugin/MessageStack.pm
+++ b/lib/Catalyst/Plugin/MessageStack.pm
@@ -162,6 +162,7 @@ sub message {
             $s->{id}      = $message->{message};
             $s->{scope}   = $message->{scope} || 'global';
             $s->{subject} = $message->{subject} if($message->{subject});
+            $s->{params}  = $message->{params} if($message->{params});
         } else {
             $s->{level}   = $default;
             $s->{id}      = $message;

--- a/t/messages.t
+++ b/t/messages.t
@@ -19,7 +19,8 @@ is_deeply($c->message({
     scope => 'some_scope',
     message => 'this is a message',
     type => 'info',
-    subject => 'verb'
+    subject => 'verb',
+    params => ['string_param', 10]
 }), bless({
     messages => [
       bless({
@@ -27,6 +28,7 @@ is_deeply($c->message({
         msgid   => "this is a message",
         scope   => "some_scope",
         subject => "verb",
+        params  => ["string_param", 10],
       }, "Message::Stack::Message"),
    ],
 }, "Message::Stack"), 'One message in the stash');
@@ -44,6 +46,7 @@ is_deeply($c->message({
         msgid   => "this is a message",
         scope   => "some_scope",
         subject => "verb",
+        params  => ["string_param", 10],
       }, "Message::Stack::Message"),
       bless({
         level   => "error",
@@ -67,6 +70,7 @@ is_deeply($c->message($msg), bless({
         msgid   => "this is a message",
         scope   => "some_scope",
         subject => "verb",
+        params  => ["string_param", 10],
       }, "Message::Stack::Message"),
       bless({
         level   => "error",
@@ -87,7 +91,8 @@ my $msg2 = Message::Stack::Message->new({
     scope => 'some_other_scope',
     id => 'this is a fourth message',
     level => 'error',
-    subject => 'verb'
+    subject => 'verb',
+    params => ['some_other_param']
 });
 is_deeply($c->message($msg2), bless({
     messages => [
@@ -96,6 +101,7 @@ is_deeply($c->message($msg2), bless({
         msgid   => "this is a message",
         scope   => "some_scope",
         subject => "verb",
+        params  => ["string_param", 10],
       }, "Message::Stack::Message"),
       bless({
         level   => "error",
@@ -114,6 +120,7 @@ is_deeply($c->message($msg2), bless({
         msgid   => "this is a fourth message",
         scope   => "some_other_scope",
         subject => "verb",
+        params  => ["some_other_param"],
       }, "Message::Stack::Message"),
    ],
 }, "Message::Stack"), 'Four messages in the stash');


### PR DESCRIPTION
This change allows the following call to work:

``` perl
my $pmt = 100;
$c->message({ type => "success", message => "payment_complete", params => [$pmt] });
```

I'm using your plugin in a project that requires localized strings, and being able to pass parameters into the stack is a requirement when the strings need interpolated variables. Currently I can pass a Message::Stack::Message object into the message() call, but having the plugin's interface support params is much cleaner.
