### PR TITLE
Fix dropped messages on multiple redirects

### DIFF
--- a/lib/Catalyst/Plugin/MessageStack.pm
+++ b/lib/Catalyst/Plugin/MessageStack.pm
@@ -250,8 +250,10 @@ sub dispatch {
 
     if ( $messages->has_messages and $c->response->location) {
         $c->flash->{$flash_key}    = $messages;
+        $c->keep_flash($flash_key);
         if ( $config->{model} ) {
             $c->flash->{$rflash_key} ||= $c->model($config->{model})->results;
+            $c->keep_flash($rflash_key);
         }
     }
     return $ret;

--- a/t/dispatch.t
+++ b/t/dispatch.t
@@ -67,6 +67,8 @@ SKIP: {
     $c->content_contains('This is a message from a POST with a custom stash_key, flash_key, results_stash_key, and results_flash_key');
  
 
+    $content = $c->get_ok('/redirect_source');
+    $c->content_contains('multiple redirects preserve messages', 'Correct body for GET /read after redirects');
 
    
 }

--- a/t/lib/TestApp/Controller/Root.pm
+++ b/t/lib/TestApp/Controller/Root.pm
@@ -71,4 +71,21 @@ sub tweak_config : Local {
     }
 }
 
+sub redirect_source : Local {
+    my $self = shift;
+    my $c = shift;
+
+    $c->message('multiple redirects preserve messages');
+
+    $c->res->redirect($c->uri_for('/redirect_intermediate'));
+}
+
+sub redirect_intermediate : Local {
+    my $self = shift;
+    my $c = shift;
+
+    $c->res->redirect($c->uri_for('/read'));
+}
+
+
 1;


### PR DESCRIPTION
I wrote a detailed explanation in 6cf60b8c07880bb599442cd13df3b51bf708c61a (and tests in 78c3d9591f49195b7beb0a250d60aac50ac3c7f1!) but here it is again for your instant gratification:

```
Catalyst::Plugin::Session::_save_flash compares object contents and
actually discards anything that matches what was there at the start
of the request. The symptom of this failure is if you redirect a few
times, messages will be lost.

If we have a controller action /permission_denied that adds a
message M, then redirects to /generic/index, which then redirects
to /real/index, then /real/index will not see that message M.
then the following bug occurs during the request to /generic/index:

1. Session pulls the saved messages out of the store, hashing its
   contents to CAFEBABE.

2. MessageStack copies flash->{_messages} into stash->{messages}.

3. The controller action runs and redirects, without interacting
   with stash->{messages} at all.

4. MessageStack notices the redirect and wants to preserve the
   existing messages so it copies stash->{messages} into
   flash->{_messages}.

5. Session decides whether to store the flash. It pulls saved
   messages out of flash->{_messages}, hashes it, and sees that its
   hash, CAFEBABE, matches what was there at the start of the
   request, so drops it.

By explicitly telling Session to keep flash->{_messages}, it doesn't
compare hashes and doesn't drop flash->{_messages} in step 5.
```

よろしくお願いします
